### PR TITLE
Add caldav_pass_command for reading the password from an external command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format of this file is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), 
 and I do try to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* `caldav_pass_command` config key and `--caldav-pass-command` command line option, for reading the CalDAV password from an external command (`pass`, `gpg`, `secret-tool`, ...) rather than storing it in plaintext in the configuration file.
+
 ## [v1.1.1] - 2026-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The list below will only contain the most important options and may
 not be up-to-date and may contain features not implemented yet.
 
 * --caldav-url, --caldav-user, --caldav-pass: how to connect to the CalDAV server.  (Fits better into a configuration file)
+* --caldav-pass-command: command printing the CalDAV password on stdout, as an alternative to --caldav-pass.  (Fits better into a configuration file)
 * --calendar-url: url to the calendar one wants to use.  A relative URL (path) or a calendar-id is also accepted.
 * --config-file: use a specific configuration file (default: $HOME/.config/calendar.conf)
 * --config-section: use a specific section from the config file (i.e. to select a different caldav-server to connect to)
@@ -211,6 +212,37 @@ work:
 private:
   contains: [ 'private-calendar', 'brothel-appointments' ]
 ```
+
+### Keeping the password out of the config file
+
+If you'd rather not store the password in plaintext, use `caldav_pass_command`
+instead of `caldav_pass`.  The command is run through the shell and the first
+line it prints on stdout is used as the password:
+
+```yaml
+---
+default:
+  caldav_url: "https://dav.example.com/"
+  caldav_user: luser
+  caldav_pass_command: "pass show caldav/dav.example.com"
+```
+
+Only the first line is used, so `pass`-style entries with metadata on the
+following lines work as-is.  Other examples: `gpg --decrypt ~/.caldav.gpg`,
+`secret-tool lookup service caldav`, `cat ~/.caldav-password`.
+
+The command inherits stdin and stderr, so interactive passphrase prompts
+(gpg/pinentry) work, and error messages from the command are shown to the
+user.  A command that fails or prints nothing is a fatal error - `plann` will
+not silently fall back to connecting without a password.
+
+`caldav_pass` takes precedence if both are given, so adding
+`caldav_pass_command` to an existing configuration changes nothing until the
+old `caldav_pass` is removed.  A warning is logged if both are set.
+
+There is also a `--caldav-pass-command` command line option.  Note that
+passing a password directly with `--caldav-pass` is insecure, as the command
+line of a running process can be read by other users on the same machine.
 
 ## Usage example
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -77,6 +77,21 @@ private:
 
 Multiple config sections can be specified, which may be useful for selecting things from multiple calendars.
 
+To avoid storing the password in plaintext, replace `caldav_pass` with
+`caldav_pass_command`.  The command is run through the shell, and the first
+line printed on stdout is used as the password:
+
+```yaml
+---
+default:
+  caldav_url: "https://dav.example.com/"
+  caldav_user: luser
+  caldav_pass_command: "pass show caldav/dav.example.com"
+```
+
+Note that `caldav_pass` wins if both keys are present - remove it when
+switching over.
+
 ## Adding things to the calendar
 
 Generally it should be done like this:

--- a/plann/cli.py
+++ b/plann/cli.py
@@ -38,7 +38,7 @@ from plann.commands import (
     _split_high_pri_tasks,
     _split_huge_tasks,
 )
-from plann.config import config_section, expand_config_section, read_config
+from plann.config import PasswordCommandError, config_section, expand_config_section, read_config
 from plann.interactive import _abort
 from plann.lib import _list, _split_vcal, _split_vcals, attr_int, attr_time, attr_txt_many, attr_txt_one, find_calendars
 from plann.lib import add_time_tracking as add_time_tracking_
@@ -73,6 +73,7 @@ list_type = list
 @click.option('--caldav-url', help="Full URL to the caldav server", metavar='URL')
 @click.option('--caldav-username', '--caldav-user', help="Full URL to the caldav server", metavar='URL')
 @click.option('--caldav-password', '--caldav-pass', help="Password for the caldav server", metavar='URL')
+@click.option('--caldav-password-command', '--caldav-pass-command', help="Command printing the caldav password to stdout", metavar='CMD')
 @click.option('--calendar-url', help="Calendar id, path or URL", metavar='cal', multiple=True)
 @click.option('--calendar-name', help="Calendar name", metavar='cal', multiple=True)
 @click.option('--raise-errors/--print-errors', help="Raise errors found on calendar discovery")
@@ -91,15 +92,18 @@ def cli(ctx, **kwargs):
     ## TODO: logic to read the config file and edit kwargs from config file
     ## TODO: delayed communication with caldav server (i.e. if --help is given to subcommand)
     ## TODO: catch errors, present nice error messages
-    ctx.obj['calendars'] = find_calendars(kwargs, kwargs['raise_errors'])
-    for flag in ('show_native_timezone', 'store_timezone', 'implicit_timezone'):
-        setattr(tz, flag, kwargs[flag])
-    if not kwargs['skip_config']:
-        config = read_config(kwargs['config_file'])
-        if config:
-            for meta_section in kwargs['config_section']:
-                for section in expand_config_section(config, meta_section):
-                    ctx.obj['calendars'].extend(find_calendars(config_section(config, section), raise_errors=kwargs['raise_errors']))
+    try:
+        ctx.obj['calendars'] = find_calendars(kwargs, kwargs['raise_errors'])
+        for flag in ('show_native_timezone', 'store_timezone', 'implicit_timezone'):
+            setattr(tz, flag, kwargs[flag])
+        if not kwargs['skip_config']:
+            config = read_config(kwargs['config_file'])
+            if config:
+                for meta_section in kwargs['config_section']:
+                    for section in expand_config_section(config, meta_section):
+                        ctx.obj['calendars'].extend(find_calendars(config_section(config, section), raise_errors=kwargs['raise_errors']))
+    except PasswordCommandError as error:
+        raise click.ClickException(str(error)) from error
 
 @cli.command()
 @click.pass_context

--- a/plann/config.py
+++ b/plann/config.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import subprocess
 import time
 from fnmatch import fnmatch
 from getpass import getpass
@@ -151,6 +152,32 @@ def config_section(config, section='default'):
     if section in config:
         ret.update(config[section])
     return ret
+
+class PasswordCommandError(RuntimeError):
+    """Raised when a configured caldav_pass_command cannot deliver a password"""
+
+def password_from_command(command):
+    """
+    Run `command` and return the first line it prints on stdout.
+
+    `command` is run through the shell when given as a string, and executed
+    directly when given as a list.  Only stdout is captured - stdin and stderr
+    are inherited, so interactive helpers like gpg/pinentry keep working and
+    error messages from the command reach the user.
+
+    Only the first line is used, as password managers like `pass` print the
+    password on the first line followed by other metadata.
+    """
+    try:
+        completed = subprocess.run(command, shell=isinstance(command, str), stdout=subprocess.PIPE, text=True, check=True)
+    except OSError as error:
+        raise PasswordCommandError(f"could not run password command {command!r}: {error}") from error
+    except subprocess.CalledProcessError as error:
+        raise PasswordCommandError(f"password command {command!r} exited with status {error.returncode}") from error
+    lines = completed.stdout.splitlines()
+    if not lines or not lines[0]:
+        raise PasswordCommandError(f"password command {command!r} did not print a password")
+    return lines[0]
 
 def read_config(fn, interactive_error=False):
     ## This can probably be refactored into fewer lines ...

--- a/plann/lib.py
+++ b/plann/lib.py
@@ -17,6 +17,7 @@ import caldav
 import click  ## TODO - this should be removed, eventually
 import icalendar
 
+from plann.config import password_from_command
 from plann.template import Template
 from plann.timespec import (
     _ensure_ts,
@@ -105,6 +106,9 @@ def find_calendars(args, raise_errors):
     for k in args:
         if k.startswith('caldav_') and args[k]:
             key = k[7:]
+            ## not a DAVClient parameter - resolved into `password` below
+            if key in ('pass_command', 'password_command'):
+                continue
             if key == 'pass':
                 key = 'password'
             if key == 'user':
@@ -116,6 +120,7 @@ def find_calendars(args, raise_errors):
     extra_params = {}
     if 'extra_params' in conn_params:
         extra_params = conn_params.pop('extra_params')
+    pass_command = args.get('caldav_pass_command') or args.get('caldav_password_command')
     calendars = []
     ## TODO: test this more thoroughly.
     ## The code above is supposed to remote the `caldav_`-prefix
@@ -123,6 +128,14 @@ def find_calendars(args, raise_errors):
     ## https://github.com/pycalendar/plann/issues/11, credits to @bergercookie
     if 'caldav_url' in conn_params:
         conn_params['url'] = conn_params.pop('caldav_url')
+    ## resolved as late as possible, so that the password command is only run
+    ## when we actually are about to connect somewhere - and never when an
+    ## explicitly configured password already takes precedence over it
+    if conn_params and pass_command:
+        if conn_params.get('password'):
+            logging.warning("both a caldav password and a caldav password command is configured - ignoring the password command")
+        else:
+            conn_params['password'] = password_from_command(pass_command)
     if conn_params:
         client = caldav.DAVClient(**conn_params)
         principal = _try(client.principal, {}, conn_params['url'])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,99 @@
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from plann.config import PasswordCommandError, password_from_command
+from plann.lib import find_calendars
+
+
+def _script(code):
+    """A shell command running `code` in the interpreter running the tests"""
+    return f"{sys.executable} -c {code!r}"
+
+
+def test_password_from_command_string_is_run_through_the_shell():
+    assert password_from_command(_script("print('sekrit')")) == 'sekrit'
+
+
+def test_password_from_command_list_is_run_without_shell():
+    assert password_from_command([sys.executable, '-c', "print('sekrit')"]) == 'sekrit'
+
+
+def test_password_from_command_uses_first_line_only():
+    """`pass show` prints the password on the first line, metadata below"""
+    assert password_from_command(_script("print('sekrit'); print('login: luser')")) == 'sekrit'
+
+
+def test_password_from_command_keeps_significant_whitespace():
+    assert password_from_command(_script("print(' sek rit ')")) == ' sek rit '
+
+
+def test_password_from_command_rejects_nonzero_exit():
+    with pytest.raises(PasswordCommandError, match='exited with status 3'):
+        password_from_command(_script("import sys; print('sekrit'); sys.exit(3)"))
+
+
+def test_password_from_command_rejects_empty_output():
+    with pytest.raises(PasswordCommandError, match='did not print a password'):
+        password_from_command(_script("pass"))
+
+
+def test_password_from_command_rejects_blank_first_line():
+    with pytest.raises(PasswordCommandError, match='did not print a password'):
+        password_from_command(_script("print(); print('sekrit')"))
+
+
+def test_password_from_command_rejects_missing_executable():
+    with pytest.raises(PasswordCommandError, match='could not run password command'):
+        password_from_command(['plann-no-such-executable'])
+
+
+@patch("plann.lib.caldav.DAVClient")
+def test_find_calendars_resolves_pass_command(davclient):
+    """caldav_pass_command must reach DAVClient as `password`, and never as itself"""
+    find_calendars({
+        'caldav_url': 'http://caldav.example.com/',
+        'caldav_user': 'luser',
+        'caldav_pass_command': _script("print('sekrit')"),
+    }, raise_errors=True)
+    conn_params = davclient.call_args.kwargs
+    assert conn_params['password'] == 'sekrit'
+    assert conn_params['username'] == 'luser'
+    assert conn_params['url'] == 'http://caldav.example.com/'
+    assert 'pass_command' not in conn_params
+
+
+@patch("plann.lib.caldav.DAVClient")
+def test_find_calendars_accepts_password_command_spelling(davclient):
+    """--caldav-password-command lands in kwargs as caldav_password_command"""
+    find_calendars({
+        'caldav_url': 'http://caldav.example.com/',
+        'caldav_password_command': _script("print('sekrit')"),
+    }, raise_errors=True)
+    conn_params = davclient.call_args.kwargs
+    assert conn_params['password'] == 'sekrit'
+    assert 'password_command' not in conn_params
+
+
+@patch("plann.lib.caldav.DAVClient")
+def test_find_calendars_explicit_password_wins_over_pass_command(davclient, caplog):
+    """Backward compatibility - an existing hardcoded password keeps working untouched.
+
+    The password command must not even be run, so it is set to something that
+    would raise PasswordCommandError if it were.
+    """
+    find_calendars({
+        'caldav_url': 'http://caldav.example.com/',
+        'caldav_pass': 'plaintext',
+        'caldav_pass_command': 'exit 1',
+    }, raise_errors=True)
+    assert davclient.call_args.kwargs['password'] == 'plaintext'
+    assert 'ignoring the password command' in caplog.text
+
+
+@patch("plann.lib.caldav.DAVClient")
+def test_find_calendars_without_connection_does_not_run_pass_command(davclient):
+    """No server to connect to - the password command should not be run at all"""
+    assert find_calendars({'caldav_pass_command': 'exit 1'}, raise_errors=True) == []
+    davclient.assert_not_called()


### PR DESCRIPTION
The only way to configure a CalDAV password is to write it in plaintext into `calendar.conf`. `--caldav-pass` is worse, as the command line of a running process is readable by other users via `/proc/<pid>/cmdline`. There is no env var support either, and the config file is not variable-expanded, so `caldav_pass: $CALDAV_PASSWORD` authenticates with that literal string.

This adds a `caldav_pass_command` config key and a matching `--caldav-pass-command` option, following the `passwordeval`/`PassCmd` convention from msmtp and mbsync:

```yaml
---
default:
  caldav_url: "https://dav.example.com/"
  caldav_user: luser
  caldav_pass_command: "pass show caldav/dav.example.com"
```

An explicitly configured `caldav_pass` **keeps taking precedence** for backward compatibility, so existing configurations behave exactly as before.

